### PR TITLE
Ensure JSON:API compliance

### DIFF
--- a/packages/ts-json-api/CHANGELOG.md
+++ b/packages/ts-json-api/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.1] - 2021-01-08
+### Added
+- `publication links` interface as part of the JSON:API 1.0 specification
+
+### Changed
+- `meta` key in `link` object to be optional to be JSON:API 1.0 compliant
+
 ## [1.0.0] - 2020-02-17
 ### Changed
 - Moved to [TSDX](https://https://github.com/palmerhq/tsdx) for development.

--- a/packages/ts-json-api/src/types/requests.ts
+++ b/packages/ts-json-api/src/types/requests.ts
@@ -1,5 +1,5 @@
 import { NewResourceObject, ResourceObject } from './resourceObjects';
-import { Links, Meta } from './shared';
+import { Meta, TopLevelLinks } from './shared';
 
 /**
  * A Request to be sent to a JSON API-compliant server.
@@ -11,7 +11,7 @@ export interface Request<
 > {
     data: D;
     included?: ResourceObject[];
-    links?: Links;
+    links?: TopLevelLinks;
     errors?: [Error];
     meta?: Meta;
 }

--- a/packages/ts-json-api/src/types/responses.ts
+++ b/packages/ts-json-api/src/types/responses.ts
@@ -1,5 +1,5 @@
 import { ResourceObject, ResourceObjectOrObjects } from './resourceObjects';
-import { Links, Meta } from './shared';
+import { Links, Meta, TopLevelLinks } from './shared';
 
 /**
  * A Response for sure containing data.
@@ -9,7 +9,7 @@ export interface ResponseWithData<
 > {
     data: D;
     included?: ResourceObject[];
-    links?: Links;
+    links?: TopLevelLinks;
     errors?: Error[];
     meta?: Meta;
 }
@@ -22,7 +22,7 @@ export interface ResponseWithErrors<
 > {
     data?: D;
     included?: ResourceObject[];
-    links?: Links;
+    links?: TopLevelLinks;
     errors: Error[];
     meta?: Meta;
 }
@@ -35,7 +35,7 @@ export interface ResponseWithMetaData<
 > {
     data?: D;
     included?: ResourceObject[];
-    links?: Links;
+    links?: TopLevelLinks;
     errors?: Error[];
     meta: Meta;
 }
@@ -48,7 +48,7 @@ export interface Response<
 > {
     data?: D;
     included?: ResourceObject[];
-    links?: Links;
+    links?: TopLevelLinks;
     errors?: Error[];
     meta?: Meta;
 }

--- a/packages/ts-json-api/src/types/shared.ts
+++ b/packages/ts-json-api/src/types/shared.ts
@@ -1,16 +1,29 @@
 /**
+ * A single Link.
+ */
+export type Link = string | LinkObject;
+
+/**
  * An index of Links.
  */
 export interface Links {
-    [index: string]: string | LinkObject;
+    [index: string]: Link;
 }
 
+/**
+ * Top level pagination Links.
+ */
 export interface PaginationLinks {
-    first?: string | LinkObject | null;
-    last?: string | LinkObject | null;
-    prev?: string | LinkObject | null;
-    next?: string | LinkObject | null;
+    first?: Link | null;
+    last?: Link | null;
+    prev?: Link | null;
+    next?: Link | null;
 }
+
+/**
+ * The top level Links.
+ */
+export type TopLevelLinks = Links & PaginationLinks;
 
 /**
  * A Link.

--- a/packages/ts-json-api/src/types/shared.ts
+++ b/packages/ts-json-api/src/types/shared.ts
@@ -5,6 +5,13 @@ export interface Links {
     [index: string]: string | LinkObject;
 }
 
+export interface PaginationLinks {
+    first?: string | LinkObject | null;
+    last?: string | LinkObject | null;
+    prev?: string | LinkObject | null;
+    next?: string | LinkObject | null;
+}
+
 /**
  * A Link.
  */

--- a/packages/ts-json-api/src/types/shared.ts
+++ b/packages/ts-json-api/src/types/shared.ts
@@ -10,7 +10,7 @@ export interface Links {
  */
 export interface LinkObject {
     href: string;
-    meta: Meta;
+    meta?: Meta;
 }
 
 /**


### PR DESCRIPTION
This pull request will address a mismatch between the LinkObject and the JSON:API schema specification.

This pull request will also provide an interface for `pagination` links which is also described in the JSON:API schema specification.

See: https://jsonapi.org/faq/#is-there-a-json-schema-describing-json-api

Closes #5 