### PR TITLE
Allow null or undefined for set/add relationship on success

### DIFF
--- a/packages/jason-api/src/types/request.ts
+++ b/packages/jason-api/src/types/request.ts
@@ -40,7 +40,9 @@ interface Transformer<DataOut = any> {
     (response: any): ResponseShape<DataOut>;
 }
 
-type SetRelationshipOnSuccess = [string, string, string, FlexiblePayload | null | undefined];
+type SetRelationshipOnSuccess =
+    | [string, string, string]
+    | [string, string, string, FlexiblePayload];
 
 type AddRelationshipOnSuccess = [string, string, string, FlexiblePayload | null | undefined];
 

--- a/packages/jason-api/src/types/request.ts
+++ b/packages/jason-api/src/types/request.ts
@@ -41,10 +41,12 @@ interface Transformer<DataOut = any> {
 }
 
 type SetRelationshipOnSuccess =
-    | [string, string, string]
+    [string, string, string]
     | [string, string, string, FlexiblePayload];
 
-type AddRelationshipOnSuccess = [string, string, string, FlexiblePayload | null | undefined];
+type AddRelationshipOnSuccess =
+    [string, string, string]
+    | [string, string, string, FlexiblePayload];
 
 type RemoveRelationshipOnSuccess = [string, string, string, string];
 type RemoveResourceObjectOnSuccess = [string, string];

--- a/packages/jason-api/src/types/request.ts
+++ b/packages/jason-api/src/types/request.ts
@@ -40,9 +40,9 @@ interface Transformer<DataOut = any> {
     (response: any): ResponseShape<DataOut>;
 }
 
-type SetRelationshipOnSuccess = [string, string, string, FlexiblePayload];
+type SetRelationshipOnSuccess = [string, string, string, FlexiblePayload | null | undefined];
 
-type AddRelationshipOnSuccess = [string, string, string, FlexiblePayload];
+type AddRelationshipOnSuccess = [string, string, string, FlexiblePayload | null | undefined];
 
 type RemoveRelationshipOnSuccess = [string, string, string, string];
 type RemoveResourceObjectOnSuccess = [string, string];


### PR DESCRIPTION
addRelationshipOnSuccess and setRelationshipOnSuccess already support passing null or undefined as the 4th parameter to use the API response. This updates the types to reflect this.