### PR TITLE
Top-level jsonapi object support

### DIFF
--- a/packages/ts-json-api/src/types/responses.ts
+++ b/packages/ts-json-api/src/types/responses.ts
@@ -1,5 +1,5 @@
 import { ResourceObject, ResourceObjectOrObjects } from './resourceObjects';
-import { Links, Meta, TopLevelLinks } from './shared';
+import { Links, Meta, TopLevelJsonApi, TopLevelLinks } from './shared';
 
 /**
  * A Response for sure containing data.
@@ -10,6 +10,7 @@ export interface ResponseWithData<
     data: D;
     included?: ResourceObject[];
     links?: TopLevelLinks;
+    jsonapi?: TopLevelJsonApi;
     errors?: Error[];
     meta?: Meta;
 }
@@ -23,6 +24,7 @@ export interface ResponseWithErrors<
     data?: D;
     included?: ResourceObject[];
     links?: TopLevelLinks;
+    jsonapi?: TopLevelJsonApi;
     errors: Error[];
     meta?: Meta;
 }
@@ -36,6 +38,7 @@ export interface ResponseWithMetaData<
     data?: D;
     included?: ResourceObject[];
     links?: TopLevelLinks;
+    jsonapi?: TopLevelJsonApi;
     errors?: Error[];
     meta: Meta;
 }
@@ -49,6 +52,7 @@ export interface Response<
     data?: D;
     included?: ResourceObject[];
     links?: TopLevelLinks;
+    jsonapi?: TopLevelJsonApi;
     errors?: Error[];
     meta?: Meta;
 }

--- a/packages/ts-json-api/src/types/shared.ts
+++ b/packages/ts-json-api/src/types/shared.ts
@@ -25,6 +25,17 @@ export interface PaginationLinks {
  */
 export type TopLevelLinks = Links & PaginationLinks;
 
+
+/**
+ * The top level jsonapi member.
+ * @see https://jsonapi.org/format/#document-jsonapi-object
+ */
+export interface TopLevelJsonApi {
+    version?: string;
+    meta?: Meta;
+}
+
+
 /**
  * A Link.
  */


### PR DESCRIPTION
Add support for the top-level `jsonapi` member.

Doc: https://jsonapi.org/format/#document-jsonapi-object


**Example**
```
{
  "jsonapi": {
    "version": "1.0"
  }
}
```