### PR TITLE
fix(jason-api) Cache-check clashes in useAutoRequest()

### DIFF
--- a/packages/jason-api/CHANGELOG.md
+++ b/packages/jason-api/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+-   Cache-checking clashes in `useAutoRequest()` when changing action shape.
+
 ## [1.3.6] - 2022-10-11
 
 ### Fixed

--- a/packages/jason-api/src/redux/hooks/useAutoRequest.ts
+++ b/packages/jason-api/src/redux/hooks/useAutoRequest.ts
@@ -44,7 +44,7 @@ export const useAutoRequest = <Data = any>(
 
     /************************************************
      *
-     * Handle NON `cacheFirst` schema. It does not
+     * Handle NON `cacheOnce` schema. It does not
      * rely on a cached response being present.
      *
      ************************************************/

--- a/packages/jason-api/src/redux/hooks/useAutoRequest.ts
+++ b/packages/jason-api/src/redux/hooks/useAutoRequest.ts
@@ -59,9 +59,8 @@ export const useAutoRequest = <Data = any>(
 
     /************************************************
      *
-     * Handle `cacheOnce` schema. It depends on the
-     * present on whether a cached response is available,
-     * and is handled differently.
+     * Handle `cacheOnce` schema. It depends on
+     * whether a cached response is available.
      *
      ************************************************/
 

--- a/packages/jason-api/src/redux/hooks/useAutoRequest.ts
+++ b/packages/jason-api/src/redux/hooks/useAutoRequest.ts
@@ -59,7 +59,7 @@ export const useAutoRequest = <Data = any>(
 
     /************************************************
      *
-     * Handle `cacheFirst` schema. It depends on the
+     * Handle `cacheOnce` schema. It depends on the
      * present on whether a cached response is available,
      * and is handled differently.
      *


### PR DESCRIPTION
The multiple `useEffect()` calls in `useAutoRequest()` could get out of sync. When switching action shapes (in order to fetch different data), we would mistakenly think we have cached data when using `cacheOnce` cache scheme.

This solution:
1. Remove the ref, so we don't have to track it separately.
2. Handles `cacheFirst` in a separate `useEffect()`, because it depends on the presence of a cached response, while other cache schemes do not.